### PR TITLE
Remove unneeded `is rw`

### DIFF
--- a/lib/Getopt/Type.pm
+++ b/lib/Getopt/Type.pm
@@ -18,7 +18,7 @@ class Getopt::Type::Constraint {
         self.bless(:%accepted, :$results);
     }
 
-    method ACCEPTS($opts is rw) {
+    method ACCEPTS($opts) {
         for $opts.kv -> $k, $v {
             if %!accepted{$k} {
                 $!results{$k} = $v;


### PR DESCRIPTION
It used to work with `is rw` in previous Rakudo releases even
though it was incorrect. Future rakudo releases may include a fix, so
changing it according to that. Basically, the Hash object there is
already writable so `is rw` is not needed. Without `is rw` it works on
all v6.c rakudo releases.